### PR TITLE
Allow gdal to throw exception

### DIFF
--- a/server/util.py
+++ b/server/util.py
@@ -9,6 +9,9 @@ from TileStache import parseConfig
 from girder.utility.model_importer import ModelImporter
 from girder.plugins.girder_ktile.style import getColorList
 
+# Python bindings do not raise exceptions unless you
+# explicitly call UseExceptions()
+gdal.UseExceptions()
 
 def getValueList(start, stop, count):
     sequence = []
@@ -116,8 +119,11 @@ def queryLayer(file, lat, lon):
 
     for i in range(dataset.RasterCount):
         band = dataset.GetRasterBand(i+1)
-        value = band.ReadRaster(px, py, 1, 1, buf_type=gdal.GDT_Float32)
-        if value:
-            result['band_{}'.format(i+1)] = struct.unpack('f', value)[0]
+        try:
+            value = band.ReadRaster(px, py, 1, 1, buf_type=gdal.GDT_Float32)
+            if value:
+                result['band_{}'.format(i+1)] = struct.unpack('f', value)[0]
+        except RuntimeError:
+            pass
 
     return result


### PR DESCRIPTION
By default, gdal python binding doesn't throw exceptions, which is the behavior we relied on.
However, another project allows gdal binding to throw an exception causing functions in this libraries fail. Since it's commonly a better thing to handle exceptions than ignore exceptions, we allow gdal to throw exceptions in this library as well.

This issue happened when gaia is used inside girder alongside with this kitle plugin. 
I don't know if this is a good choice but this PR ask gdal to throw exceptions as well in this library. 

