### PR TITLE
loose up requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mapnik==0.1
 TileStache==1.51.6
 palettable==3.0.0
-pyproj==1.9.5.1
-GDAL==2.1.3
+pyproj>=1.9.5.1
+GDAL>=2.1.3


### PR DESCRIPTION
The current config in the requirement.txt is strick which may cause some unwanted overwrite of pip dependencies. I am not sure if the other three dependencies should loosen up as well. 